### PR TITLE
Update gen.yaml

### DIFF
--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: Gusto
+  sdkClassName: Api
   maintainOpenAPIOrder: true
   usageSnippets:
     optionalPropertyRendering: withExample
@@ -28,6 +28,6 @@ ruby:
       webhooks: models/webhooks
   inputModelSuffix: input
   maxMethodParams: 4
-  module: OpenApiSdk
+  module: GustoEmbedded
   outputModelSuffix: output
   packageName: gusto

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: Api
+  sdkClassName: Client
   maintainOpenAPIOrder: true
   usageSnippets:
     optionalPropertyRendering: withExample


### PR DESCRIPTION
Update the module and class name options

So client can be initialized with `GustoEmbedded::Client.new` instead of `OpenApiSdk::Gusto.new`.