### PR TITLE
changes name from gusto to gusto_embedded

### DIFF
--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -31,4 +31,4 @@ ruby:
   maxMethodParams: 4
   module: GustoEmbedded
   outputModelSuffix: output
-  packageName: gusto
+  packageName: gusto_embedded


### PR DESCRIPTION
`gusto` already exists in ruby gems, we need to choose a unique gem name.