### PR TITLE
pins speakeasy version

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: latest
+speakeasyVersion: 1.513.4
 sources:
     GustoEmbedded-OAS:
         inputs:


### PR DESCRIPTION
Speakeasy released a bug in the latest version of the CLI. Since ruby code generation is still in beta, I'm going to pin the version to the latest version that we know works. We'll have to manually update every once in a while to keep getting updates, but with the version pinned we don't risk generating and releasing broken code.