### PR TITLE
feat: add MIT license to Speakeasy SDK generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 /.speakeasy/reports
 /.speakeasy/temp
+.speakeasy/workflow.local.yaml

--- a/.speakeasy/workflow.local.example
+++ b/.speakeasy/workflow.local.example
@@ -1,3 +1,10 @@
+# Template for local SDK generation. Copy this file to workflow.local.yaml before use.
+# Intended for Gusto engineers with access to the internal API specification repository.
+# External contributors: local generation requires access to internal Gusto repositories
+# and is not supported outside of Gusto's development environment.
+#
+# Setup: run bin/setup-local to create workflow.local.yaml automatically.
+# Usage: speakeasy run --target=local
 sources:
   GustoEmbedded-local:
     inputs:

--- a/bin/setup-local
+++ b/bin/setup-local
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+DEST=".speakeasy/workflow.local.yaml"
+EXAMPLE=".speakeasy/workflow.local.example"
+
+if [ -f "$DEST" ]; then
+  echo "$DEST already exists — skipping"
+  exit 0
+fi
+
+cp "$EXAMPLE" "$DEST"
+echo "Created $DEST"
+echo ""
+echo "Note: local generation requires access to internal Gusto repositories."
+echo "Run: speakeasy run --target=local"

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -14,6 +14,10 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
+  license:
+    disabled: false
+    licenseType: MIT
+    companyName: Gusto
 ruby:
   version: 0.2.11
   author: Gusto

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -14,10 +14,6 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
-  license:
-    disabled: false
-    licenseType: MIT
-    companyName: Gusto
 ruby:
   version: 0.2.11
   author: Gusto
@@ -32,6 +28,7 @@ ruby:
       shared: models/shared
       webhooks: models/webhooks
   inputModelSuffix: input
+  license: MIT
   maxMethodParams: 4
   module: GustoEmbedded
   outputModelSuffix: output

--- a/gusto_embedded/LICENSE
+++ b/gusto_embedded/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gusto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Adds \`ruby.license: MIT\` to \`gen.yaml\` — the [correct location](https://www.speakeasy.com/docs/speakeasy-reference/generation/ruby-config) per Speakeasy docs
- Manually adds \`gusto_embedded/LICENSE\` (MIT)

> **Note:** The gemspec \`s.licenses\` field is currently hardcoded to \`['Apache-2.0']\` by Speakeasy's Ruby generator. The \`ruby.license\` config field does not override it. A separate fix or Speakeasy support request would be needed to correct the gemspec license declaration.

## Test plan

- [ ] Run \`speakeasy run --target=local\` locally and confirm generation succeeds
- [ ] Confirm \`gusto_embedded/LICENSE\` exists with MIT license text